### PR TITLE
Upacst logits for accuracy metric computation to fp32

### DIFF
--- a/axlearn/common/causal_lm.py
+++ b/axlearn/common/causal_lm.py
@@ -281,6 +281,9 @@ class Model(BaseModel):
         target_labels: Tensor,
         target_num_bytes: Optional[Tensor],
     ) -> Dict[str, Tensor]:
+        if logits.dtype in (jnp.bfloat16, jnp.float16):
+            logits = logits.astype(jnp.float32)
+
         live_targets = (target_labels != self.decoder.config.pad_token_id) & (target_labels >= 0)
         num_targets = live_targets.sum()
         accuracy = (

--- a/axlearn/experiments/text/gpt/fuji.py
+++ b/axlearn/experiments/text/gpt/fuji.py
@@ -68,7 +68,9 @@ MAX_SEQUENCE_LENGTH = {
 TP_DEGREE = int(os.environ.get('TP_DEGREE', '64'))
 TRN_MODEL_AXIS_SIZE = TP_DEGREE
 
-GRADIENT_ACCUMULATION_MICROBATCHES=1
+GRADIENT_ACCUMULATION_MICROBATCHES = int(
+        os.environ.get("NEURON_GRAD_ACC_COUNT",1))
+NUM_NODES = int(os.environ.get("NEURON_NUM_NODES",1))
 
 ROPE_THETA = {
     Version.V1: 5e5,
@@ -110,6 +112,10 @@ def get_trainer_kwargs(
     tokens_per_batch = 4 * (1024**2)  # 4M tokens.
     max_step = TOTAL_TOKENS[version][model_size] // tokens_per_batch
     max_sequence_length = MAX_SEQUENCE_LENGTH[version]
+    train_batch_size  = int(jax.device_count()/TRN_MODEL_AXIS_SIZE)
+    train_batch_size *= GRADIENT_ACCUMULATION_MICROBATCHES
+    train_batch_size *= NUM_NODES 
+
 
     # Whether to use grouped query attention.
     num_kv_heads = None

--- a/run_trainer.sh
+++ b/run_trainer.sh
@@ -16,6 +16,13 @@ HLO_DUMP_PATH=${TEST_ARTIFACTS_PATH}/hlo_dump
 export XLA_FLAGS="--xla_dump_hlo_as_text --xla_disable_hlo_passes=aws_neuron_flip_all_gather_dot --xla_dump_hlo_as_proto --xla_dump_to=${HLO_DUMP_PATH} --xla_dump_hlo_pass_re='.*'"
 
 
+#Config
+:${NEURON_NUM_NODES:=100000}
+:${NEURON_GRAD_ACC_COUNT=1}
+
+export NEURON_NUM_NODES
+export NEURON_GRAD_ACC_COUNT
+
 # Neuron compiler flags
 export NEURON_CC_FLAGS="--framework=XLA"
 export NEURON_CC_FLAGS="${NEURON_CC_FLAGS} --target=trn2 --distribution-strategy=llm-training"

--- a/run_trn.sh
+++ b/run_trn.sh
@@ -3,4 +3,4 @@
 #SBATCH --exclusive
 #SBATCH --nodes=1
 
-srun  --kill-on-bad-exit=1  run_trainer.sh
+srun  --kill-on-bad-exit=1  run_trainer.sh "$@"


### PR DESCRIPTION
Upacst logits for accuracy metric computation to fp32.  GPU implementation contains an implicit cast to FP32, we make it explicit for TRN1. This matches computation of duped accuracy from FP32 logits in /axlearn/common/loss.py.